### PR TITLE
Added additional commands needed to install OpenCV due to homebrew changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Navigate with the terminal to the build directory
 * `brew install gfortran`
 * `easy_install numpy`
 * `brew install cmake`
+* `brew tap homebrew/science`
 * `brew install opencv`
 * `cmake` build the project
 


### PR DESCRIPTION
Just was trying to follow the installation instructions to install OpenTLD and ran into a problem that brew could not find a formula for opencv.  Apparently it got moved to the homebrew/science tap and so you need an extra command to install it now.